### PR TITLE
Addressing review comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ ethconnect-go-tux
 ethconnect-go-mac
 coverage.txt
 **/debug.test
-.vscode
+.vscode/*
+!.vscode/settings.json
 .DS_Store

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,63 @@
+run:
+  tests: false
+linters-settings:
+  golint: {}
+  staticcheck:
+    go: "1.16"
+    checks: ["all"]
+  stylecheck:
+    go: "1.16"
+    checks: ["all", "-ST1005"]
+  gocritic:
+    enabled-checks: []
+    disabled-checks:
+      - regexpMust
+    enabled-tags:
+      - performance
+  goheader:
+    template: |-
+      Copyright © {{ YEAR }} Kaleido, Inc.
+      
+      SPDX-License-Identifier: Apache-2.0
+      
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+      
+          http://www.apache.org/licenses/LICENSE-2.0
+      
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+linters:
+  disable-all: false
+  enable:
+  # - bodyclose
+  # - deadcode
+  # - depguard
+  # - dogsled
+  # - errcheck
+  # - goconst
+  # - gocritic
+  # - gocyclo
+  - gofmt
+  # - goheader
+  # - goimports
+  # - goprintffuncname
+  # - gosec
+  # - gosimple
+  # - govet
+  # - ineffassign
+  # - misspell
+  # - nakedret
+  # - revive
+  - staticcheck
+  # - structcheck
+  - stylecheck
+  - typecheck
+  # - unconvert
+  # - unparam
+  # - unused
+  # - varcheck

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "go.lintTool": "golangci-lint"
+}

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,15 @@ GOFILES := $(shell find . -name '*.go' -print)
 all: deps build test
 build: ethbinding.so
 		$(VGO) build -ldflags "-X main.buildDate=`date -u +\"%Y-%m-%dT%H:%M:%SZ\"` -X main.buildVersion=$(BUILD_VERSION)" -tags=prod -o $(BINARY_NAME) -v
-ethbinding.so:	  
+ethbinding.so:
 	  go build -buildmode=plugin github.com/kaleido-io/ethbinding
-# if using delv or vscode to debug, use the command below, otherwise you will get error:
+clean-ethbinding: force
+	  rm ethbinding.so
+reset-ethbinding: clean-ethbinding ethbinding.so ;
+delv-ethbinding: force
+# if using delv or vscode to debug, use "make vscode-ethbinding", otherwise you will get error:
 # "plugin was built with a different version of package runtime/internal/sys"
-#	  go build -buildmode=plugin -gcflags='all=-N -l' github.com/kaleido-io/ethbinding
+	  go build -buildmode=plugin -gcflags='all=-N -l' github.com/kaleido-io/ethbinding
 coverage.txt: $(GOFILES)
 		$(VGO) test  ./... -cover -coverprofile=coverage.txt -covermode=atomic -timeout 30s
 coverage.html:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean-ethbinding: force
 	  rm ethbinding.so
 reset-ethbinding: clean-ethbinding ethbinding.so ;
 delv-ethbinding: force
-# if using delv or vscode to debug, use "make vscode-ethbinding", otherwise you will get error:
+# if using delv or vscode to debug, use "make delv-ethbinding", otherwise you will get error:
 # "plugin was built with a different version of package runtime/internal/sys"
 	  go build -buildmode=plugin -gcflags='all=-N -l' github.com/kaleido-io/ethbinding
 coverage.txt: $(GOFILES)
@@ -45,4 +45,3 @@ build-mac:
 		GOOS=darwin GOARCH=amd64 $(VGO) build -o $(BINARY_MAC) -v
 build-win:
 		GOOS=windows GOARCH=amd64 $(VGO) build -o $(BINARY_WIN) -v
-

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/nwaples/rardecode v1.1.0 // indirect
-	github.com/oklog/ulid/v2 v2.0.2 // indirect
+	github.com/oklog/ulid/v2 v2.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -442,6 +442,11 @@ const (
 	WebhooksDirectTooManyInflight = "Too many in-flight transactions"
 	// WebhooksDirectBadHeaders problem processing for in-memory operation
 	WebhooksDirectBadHeaders = "Failed to process headers in message"
+
+	// LevelDBFailedRetriveOriginalKey problem retrieving entry - original key
+	LevelDBFailedRetriveOriginalKey = "Failed to retrieve the entry for the original key: %s. %s"
+	// LevelDBFailedRetriveGeneratedID problem retrieving entry - generated ID
+	LevelDBFailedRetriveGeneratedID = "Failed to retrieve the entry for the generated ID: %s. %s"
 )
 
 type Error string

--- a/internal/kvstore/kvstore.go
+++ b/internal/kvstore/kvstore.go
@@ -22,6 +22,9 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
+// ErrorNotFound signal error for not found
+var ErrorNotFound = leveldb.ErrNotFound
+
 // KVIterator interface for key value iterators
 type KVIterator interface {
 	Key() string

--- a/internal/rest/leveldbreceipt_test.go
+++ b/internal/rest/leveldbreceipt_test.go
@@ -339,7 +339,7 @@ func TestLevelDBReceiptsFilterFromTo(t *testing.T) {
 	assert := assert.New(t)
 
 	conf := &LevelDBReceiptStoreConf{
-		Path: path.Join(tmpdir, "test3"),
+		Path: path.Join(tmpdir, "test4"),
 	}
 	r, err := newLevelDBReceipts(conf)
 	defer r.store.Close()
@@ -393,7 +393,7 @@ func TestLevelDBReceiptsFilterNotFound(t *testing.T) {
 	assert := assert.New(t)
 
 	conf := &LevelDBReceiptStoreConf{
-		Path: path.Join(tmpdir, "test4"),
+		Path: path.Join(tmpdir, "test6"),
 	}
 	r, err := newLevelDBReceipts(conf)
 	defer r.store.Close()
@@ -449,7 +449,7 @@ func TestLevelDBReceiptsGetReceiptOK(t *testing.T) {
 	assert := assert.New(t)
 
 	conf := &LevelDBReceiptStoreConf{
-		Path: path.Join(tmpdir, "test5"),
+		Path: path.Join(tmpdir, "test7"),
 	}
 	r, err := newLevelDBReceipts(conf)
 	defer r.store.Close()
@@ -470,7 +470,7 @@ func TestLevelDBReceiptsGetReceiptsUnmarshalFailIgnoreReceipt(t *testing.T) {
 	assert := assert.New(t)
 
 	conf := &LevelDBReceiptStoreConf{
-		Path: path.Join(tmpdir, "test5"),
+		Path: path.Join(tmpdir, "test8"),
 	}
 	r, err := newLevelDBReceipts(conf)
 	defer r.store.Close()
@@ -513,7 +513,7 @@ func TestLevelDBReceiptsGetReceiptErrorID(t *testing.T) {
 	}
 
 	_, err := r.GetReceipt("receipt1")
-	assert.EqualError(err, "Failed to the entry for the original key: receipt1. pop")
+	assert.EqualError(err, "Failed to retrieve the entry for the original key: receipt1. pop")
 }
 
 func TestLevelDBReceiptsGetReceiptErrorGeneratedID(t *testing.T) {

--- a/internal/rest/leveldbreceipt_test.go
+++ b/internal/rest/leveldbreceipt_test.go
@@ -242,7 +242,7 @@ func TestLevelDBReceiptsGetReceiptsWithStartEnd(t *testing.T) {
 		i++
 	}
 
-	results, err := r.GetReceipts(0, 2, nil, 1626404000000, "", "", "") //startKey)
+	results, err := r.GetReceipts(0, 2, nil, 1626404000000, "", "", startKey)
 	assert.NoError(err)
 	assert.Equal(2, len(*results))
 	assert.Equal("value1", (*results)[0]["prop1"])

--- a/internal/rest/leveldbreceipt_test.go
+++ b/internal/rest/leveldbreceipt_test.go
@@ -218,13 +218,23 @@ func TestLevelDBReceiptsGetReceiptsWithStartEnd(t *testing.T) {
 	receipt1["receivedAt"] = 1626407000000
 	err = r.AddReceipt(id3, &receipt3)
 
+	// Some test debug info
 	itr := r.store.NewIterator()
-	i := 0
-	var startKey string
-	valid := itr.Last()
-	for ; valid; valid = itr.Prev() {
+	valid := itr.Next()
+	for ; valid; valid = itr.Next() {
 		b, _ := r.store.Get(itr.Key())
 		log.Infof("%s: %s", itr.Key(), b)
+	}
+	endKey := r.findEndPoint(1626404000000)
+	log.Infof("End key: %s", endKey)
+	itr.Release()
+
+	itr = r.store.NewIterator()
+	i := 0
+	var startKey string
+	valid = itr.Last()
+	for ; valid; valid = itr.Prev() {
+		_, _ = r.store.Get(itr.Key())
 		if i == 1 {
 			startKey = itr.Key()
 			break

--- a/internal/rest/leveldbreceipts.go
+++ b/internal/rest/leveldbreceipts.go
@@ -108,7 +108,7 @@ func (l *levelDBReceipts) GetReceipts(skip, limit int, ids []string, sinceEpochM
 	var endKey string
 	if sinceEpochMS > 0 {
 		// locate the iterator range limit
-		endKey := l.findEndPoint(sinceEpochMS)
+		endKey = l.findEndPoint(sinceEpochMS)
 		if endKey == "" {
 			// no entries match the sinceEpochMS, return empty
 			return &[]map[string]interface{}{}, nil


### PR DESCRIPTION
Hi @jimthematrix,

Made some progress on the remaining review comments, then hit an issue where I couldn't get the function that uses a `sinceEpochMS`.
Might need to talk it through with you.
If you see `TestLevelDBReceiptsGetReceiptsWithStartEnd` when it runs, it finds the last entry and sets its key in `range.Limit` ok to something like `z01FAPR90MJMQJHBF4QX1EFD6Y3`.
However, when in `getReceiptsNoFilter` we do `valid = itr.Last()`, we find key is actually `receivedAt:1626405000000:z01FAPR90MJMQJHBF4QX1EFD6Y3` 🤔 


... ok, think I worked this out.
The problem is we were setting `range.Limit`... but the entries are added in ascending timestamp order.
So actually we want to set `range.Start.

That change is now included in this PR, so this could be merged, and I can carry on with review comments in a future PR.